### PR TITLE
(fix: looc) Fix snowpack install logic and watcher options

### DIFF
--- a/looc-e2e/src/index.tsx
+++ b/looc-e2e/src/index.tsx
@@ -71,7 +71,7 @@ interface IDCardProps {
 const IDCard: React.FC<IDCardProps & { __LOOC_DEBUG__: boolean }> = ({
   firstName = "",
   lastName = "",
-  title = "",
+  titles = "",
   id = 0,
   telephone = "",
   picShape = "round",

--- a/looc/package.json
+++ b/looc/package.json
@@ -4,7 +4,7 @@
   "bin": "bin/cli.js",
   "module": "build/index.esm.js",
   "author": "jlkiri",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "typings": "build/index.d.ts",
   "files": [
     "build",

--- a/looc/src/helpers.ts
+++ b/looc/src/helpers.ts
@@ -42,17 +42,13 @@ export const snowpackInstall = async (libs: StyleLibrary[], dest: string) => {
 
   await fs.outputJSON(configPath, snowpackConfig);
 
-  try {
-    await execa("npx", [
-      `snowpack`,
-      `--config`,
-      `${configPath}`,
-      `--source`,
-      `pika`,
-    ]);
-  } catch (e) {
-    console.error("LOOC ERROR:", e);
-  }
+  await execa("npx", [
+    `snowpack`,
+    `--config`,
+    `${configPath}`,
+    `--source`,
+    `pika`,
+  ]);
 };
 
 export const readCachedData = async (cacheDir: string) => {

--- a/looc/src/index.ts
+++ b/looc/src/index.ts
@@ -3,7 +3,7 @@ import { start } from "./start";
 
 const cli = sade("looc");
 
-cli.version("0.6.0");
+cli.version("0.6.2");
 
 cli
   .command("start <filepath>")

--- a/looc/src/start.ts
+++ b/looc/src/start.ts
@@ -160,7 +160,21 @@ export const start = async (
 
     //project.emitSync();
 
-    rollup.watch({ ...inputOpts, output: outputOpts });
+    const watcher = rollup.watch({
+      ...inputOpts,
+      output: outputOpts,
+      watch: { clearScreen: true },
+    });
+
+    watcher.on("event", (event) => {
+      if (event.code === "BUNDLE_START") {
+        console.log(chalk.blue("Starting development server..."));
+      }
+      if (event.code === "ERROR") {
+        watcher.close();
+        throw event.error;
+      }
+    });
 
     /* await bundle.generate(outputOpts);
 

--- a/looc/src/start.ts
+++ b/looc/src/start.ts
@@ -155,7 +155,7 @@ export const start = async (
 
     const outputOpts = {
       dir: cacheDir,
-      plugins: [serve(cacheDir), livereload()],
+      plugins: [serve({ contentBase: cacheDir, port: 3000 }), livereload()],
     };
 
     //project.emitSync();

--- a/looc/src/start.ts
+++ b/looc/src/start.ts
@@ -96,10 +96,10 @@ export const start = async (
 
     try {
       await snowpackInstall(uninstalledLibs, cacheDir);
-    } catch {
+    } catch (e) {
       throw Error(
         chalk.bold.red(
-          `Something went wrong when trying to install required libraries!`
+          `Something went wrong when trying to install required libraries! Error: ${e}`
         )
       );
     }


### PR DESCRIPTION
Solves #7

`snowpack` could not install libraries because of network problems but it seems to think they're installed, because it outputs a json with a list of installed libs even before it installs them. 